### PR TITLE
Support mapping more mParticle identity types to Developer ID

### DIFF
--- a/dist/BranchMetrics-Kit.common.js
+++ b/dist/BranchMetrics-Kit.common.js
@@ -138,10 +138,39 @@ function IdentityHandler(common) {
     this.common = common || {};
 }
 
+
 function identified(mParticleUser, identityApiRequest) {
-    var mPUser = mParticleUser.getUserIdentities();
-    var userId = mPUser.customerid || mPUser.other || mPUser.other2 || mPUser.other3 || mPUser.other4;
-    if (typeof userId !== 'undefined') {
+    var mPUser = mParticleUser.getUserIdentities().userIdentities;
+    var userId = '';
+
+    switch (this.common.settings.userIdentificationType) {
+      case ('CustomerId'):
+        userId = mPUser.customerid;
+        break;
+      case ('MPID'):
+        userId = mParticleUser.getMPID();
+        break;
+      case ('Email'):
+        userId = mPUser.email;
+        break;
+      case ('Other'):
+        userId = mPUser.other;
+        break;
+      case ('Other2'):
+        userId = mPUser.other2;
+        break;
+      case ('Other3'):
+        userId = mPUser.other3;
+        break;
+      case ('Other4'):
+        userId = mPUser.other4;
+        break;
+      default:
+        userId = mPUser.customerid;
+        break;
+    }
+
+    if (userId !== '' && typeof userId !== undefined) {
         branch.setIdentity(userId);
     }
 }
@@ -165,7 +194,8 @@ var identityHandler = IdentityHandler;
 
 var initialization = {
     name: 'BranchMetrics',
-    initForwarder: function(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized) {
+    initForwarder: function(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized, common) {
+        common.settings = settings;
         if (!testMode) {
             if (!!window.branch) {
                 return;

--- a/dist/BranchMetrics-Kit.iife.js
+++ b/dist/BranchMetrics-Kit.iife.js
@@ -137,10 +137,39 @@ var BranchMetricsKit = (function (exports) {
         this.common = common || {};
     }
 
+
     function identified(mParticleUser, identityApiRequest) {
-        var mPUser = mParticleUser.getUserIdentities();
-        var userId = mPUser.customerid || mPUser.other || mPUser.other2 || mPUser.other3 || mPUser.other4;
-        if (typeof userId !== 'undefined') {
+        var mPUser = mParticleUser.getUserIdentities().userIdentities;
+        var userId = '';
+
+        switch (this.common.settings.userIdentificationType) {
+          case ('CustomerId'):
+            userId = mPUser.customerid;
+            break;
+          case ('MPID'):
+            userId = mParticleUser.getMPID();
+            break;
+          case ('Email'):
+            userId = mPUser.email;
+            break;
+          case ('Other'):
+            userId = mPUser.other;
+            break;
+          case ('Other2'):
+            userId = mPUser.other2;
+            break;
+          case ('Other3'):
+            userId = mPUser.other3;
+            break;
+          case ('Other4'):
+            userId = mPUser.other4;
+            break;
+          default:
+            userId = mPUser.customerid;
+            break;
+        }
+
+        if (userId !== '' && typeof userId !== undefined) {
             branch.setIdentity(userId);
         }
     }
@@ -164,7 +193,8 @@ var BranchMetricsKit = (function (exports) {
 
     var initialization = {
         name: 'BranchMetrics',
-        initForwarder: function(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized) {
+        initForwarder: function(settings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized, common) {
+            common.settings = settings;
             if (!testMode) {
                 if (!!window.branch) {
                     return;


### PR DESCRIPTION
Some slight refactoring, plus added support for mapping other kinds of mParticle IDs a customer could be using to user_data_developer_identity (e.g. MPID, various "Other" fields).
