### PR TITLE
parseFloat fix for $price key

### DIFF
--- a/src/commerce-handler.js
+++ b/src/commerce-handler.js
@@ -65,7 +65,7 @@ CommerceHandler.prototype.logCommerceEvent = function(event) {
             $product_brand: value.Brand,
             $coupon_code: value.CouponCode,
             $product_name: value.Name,
-            $price: value.Price,
+            $price: parseFloat(value.Price),
             $quantity: value.Quantity,
             $sku: value.Sku,
             $total_amount: value.TotalAmount,


### PR DESCRIPTION
fixing issue where key "price" could be sent in as a String instead of a double