### PR TITLE
[other] NO-TICKET: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BranchMetrics/attribution-eng
+* @BranchMetrics/sdk-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BranchMetrics/attribution-eng


### PR DESCRIPTION
Assigns ownership via CODEOWNERS (* @BranchMetrics/attribution-eng) as part of the service-catalogue rollout.